### PR TITLE
fix: Correct CourseForm import in Courses page

### DIFF
--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react"
 import { useRouter, usePathname } from "next/navigation"
 import MainLayout from "../layouts/MainLayout"
-import { CourseForm } from "../components/course/CourseForm"
+import CourseForm from "../components/course/CourseForm"
 import type { Course } from "../services/DataService"
 import { apiService } from "../services/ApiServiceAdapter"
 import { Button } from "../components/ui/button"


### PR DESCRIPTION
This commit fixes a build error caused by an incorrect import of the `CourseForm` component in the `Courses.tsx` file.

The `CourseForm` component is exported as a default export, but it was being imported as a named export. This commit changes the import statement to correctly import the component as a default export.