### PR TITLE
fix: Reinstall dependencies to resolve build error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3295,11 +3295,10 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "license": "Apache-2.0",
-      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
@@ -4209,9 +4208,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.214",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.214.tgz",
-      "integrity": "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==",
+      "version": "1.5.215",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.215.tgz",
+      "integrity": "sha512-TIvGp57UpeNetj/wV/xpFNpWGb0b/ROw372lHPx5Aafx02gjTBtWnEEcaSX3W2dLM3OSdGGyHX/cHl01JQsLaQ==",
       "license": "ISC"
     },
     "node_modules/embla-carousel": {
@@ -5557,16 +5556,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -6447,9 +6436,9 @@
       }
     },
     "node_modules/simple-swizzle": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.3.tgz",
-      "integrity": "sha512-NLgA1P4m+AAQuaetDKl899hwnPQd8cF0XjfIX/zdMga/kgeanRFn0MP2/HbMxPYNeJckKiB/1M4DLpb1XSWcvA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "license": "MIT",
       "optional": true,
       "peer": true,


### PR DESCRIPTION
This commit updates the `package-lock.json` file after reinstalling all dependencies. This was done to resolve a persistent build error ("Uncaught SyntaxError: The requested module '/src/components/course/CourseForm.tsx' does not provide an export named 'CourseForm'") that was likely caused by a caching issue or corrupted dependencies.

This also includes previous necessary changes to make the development server run:
- Added `lovable-tagger` dependency required by `vite.config.mts`.
- Renamed `vite.config.ts` to `vite.config.mts` to handle ES Modules.
- Changed the server host to `127.0.0.1` to avoid IPv6 issues.
- Fixed an incorrect named import of `CourseForm` in `Courses.tsx`.